### PR TITLE
Fix messages sender check

### DIFF
--- a/main.go
+++ b/main.go
@@ -331,7 +331,7 @@ func handleMessage(ctx context.Context, evt *event.Event) {
 
 	slog.Debug("received msg", "msg", msg, "sender", sender)
 
-	if sender == fmt.Sprintf("@%s:%s", *matrixUsername, *matrixHomeserver) {
+	if evt.Sender == clients.matrix.UserID {
 		slog.Debug("ignoring our own message", "msg", msg)
 
 		return


### PR DESCRIPTION
My Matrix homeserver uses matrix.dewith.io as the homeserver domain, but uses dewith.io for the server part (eg `@bot:dewith.io`. The bot expects it's own messages to come from `@bot:matrix.dewith.io` which doesn't match what it sees and therefore causes the bot to reply to its own messages. This PR fixes that by comparing the sender directly to the user as determined by the Matrix client.