### PR TITLE
Normalize attr paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,42 @@ A Matrix bot that allows you to subscribe to build failures for [nixpkgs-update]
 
 Message the bot at `@nixpkgs-update-notify-bot:matrix.org` ([link](https://matrix.to/#/@nixpkgs-update-notify-bot:matrix.org)) and type `help` to see a list of commands.
 
+## Moving parts
+
+### nixpkgs-update log page
+
+URL: `https://nixpkgs-update-logs.nix-community.org` (configurable via `-url` flag)
+
+The main page is an HTML index of `<a>` links, one per attr path (e.g. `python3Packages.diceware`). Each link points to a per-package page, which in turn lists individual log files named by date (`2024-12-10.log`). Attr path names on this page are **normalized** by the nixpkgs-update bot (e.g. `python3Packages` rather than `python312Packages`).
+
+The bot scrapes the main page on a timer and stores the normalized attr paths in the `packages` table — this is the canonical set of packages the bot knows about. It then fetches individual log files to check for build failures.
+
+### packages.json.br
+
+URL: `https://channels.nixos.org/nixos-unstable/packages.json.br`
+
+A brotli-compressed JSON file published with each nixos-unstable channel update. It contains metadata for every package in nixpkgs, keyed by attr path:
+
+```json
+{
+  "packages": {
+    "python312Packages.diceware": {
+      "meta": {
+        "maintainers": [{ "github": "asymmetric" }, ...]
+      }
+    }
+  }
+}
+```
+
+This is used exclusively by the `follow` command to look up all packages maintained by a given GitHub handle. Unlike the log page, attr paths here are **denormalized** (e.g. `python312Packages`). The bot normalizes them before storing subscriptions so they match the log page's naming.
+
 ## Limitations
 
 The bot has no access to the actual exit code of the nixpkgs-update runners, so it uses a simple heuristic to detect failures - it looks for "errory" words inside the build log.
 This is obviously fallible, and can lead to false positives and false negatives -- feel free to report them!
+
+The normalization rules mirror [`filter.sed`](https://github.com/nix-community/infra/blob/master/hosts/build02/filter.sed) from `nix-community/infra`. Some rules normalize to a specific pinned version (e.g. `beam26Packages`, `lua51Packages`) — if upstream changes that canonical version, the rules here must be updated too, or `follow` subscriptions for those package sets will silently stop matching.
 
 ## TODO
 

--- a/message_handlers.go
+++ b/message_handlers.go
@@ -339,7 +339,8 @@ func checkIfSubExists(ctx context.Context, attr_path, roomid string) (exists boo
 
 // 1. uses jquery to parse the JSON blob
 // 2. finds list of packages maintained by handle
-// 3. uses SQL to intersect with list of tracked packages
+// 3. normalizes list of maintained packages
+// 4. uses SQL to intersect with list of tracked packages
 func findPackagesForHandle(ctx context.Context, handle string) ([]string, error) {
 	// The query needs to handle:
 	// missing maintainers
@@ -373,7 +374,7 @@ func findPackagesForHandle(ctx context.Context, handle string) ([]string, error)
 
 			return nil, err
 		}
-		mps = append(mps, v.(string))
+		mps = append(mps, regexes.NormalizeAttrPath(v.(string)))
 	}
 
 	// Create the right number of placeholders: "(?,?,?)"

--- a/message_handlers_test.go
+++ b/message_handlers_test.go
@@ -467,6 +467,37 @@ func TestFollow(t *testing.T) {
 		}
 	})
 
+	t.Run("packages stored with normalized names", func(t *testing.T) {
+		// nixpkgs-update logs use normalized names (e.g. python3Packages),
+		// but packages.json has versioned names (e.g. python312Packages).
+		// follow must normalize before looking up in the packages table.
+		if err := setupDB(ctx, ":memory:"); err != nil {
+			panic(err)
+		}
+
+		normalizedPs := []string{
+			"python3Packages.diceware",
+		}
+
+		for _, p := range normalizedPs {
+			if _, err := clients.db.Exec("INSERT INTO packages(attr_path, last_visited) VALUES (?, ?)", p, "1999"); err != nil {
+				panic(err)
+			}
+		}
+
+		fol("asymmetric")
+
+		for _, p := range normalizedPs {
+			exists, err := checkIfSubExists(ctx, p, evt.RoomID.String())
+			if err != nil {
+				panic(err)
+			}
+			if !exists {
+				t.Errorf("should be subscribed to %s", p)
+			}
+		}
+	})
+
 	t.Run("some packages not tracked by nixpkgs-update", func(t *testing.T) {
 		if err := setupDB(ctx, ":memory:"); err != nil {
 			panic(err)

--- a/message_handlers_test.go
+++ b/message_handlers_test.go
@@ -409,7 +409,7 @@ func TestFollow(t *testing.T) {
 		"btrbk",
 		"btrfs-list",
 		"diceware",
-		"python312Packages.diceware",
+		"python3Packages.diceware",
 	}
 
 	t.Run("last_visited set", func(t *testing.T) {
@@ -533,7 +533,7 @@ func TestUnfollow(t *testing.T) {
 		"btrbk",
 		"btrfs-list",
 		"diceware",
-		"python312Packages.diceware",
+		"python3Packages.diceware",
 	}
 
 	all := append(mps, "foo")
@@ -574,8 +574,7 @@ func TestFindPackagesForHandle(t *testing.T) {
 			"diceware",
 			"evmdis",
 			"ledger-udev-rules",
-			"python312Packages.diceware",
-			"python313Packages.diceware",
+			"python3Packages.diceware",
 			"siji",
 			"ssb-patchwork",
 		}
@@ -634,8 +633,7 @@ func TestFindPackagesForHandle(t *testing.T) {
 			"diceware",
 			"evmdis",
 			"ledger-udev-rules",
-			"python312Packages.diceware",
-			"python313Packages.diceware",
+			"python3Packages.diceware",
 			"siji",
 			"ssb-patchwork",
 		}

--- a/regexes/regexes.go
+++ b/regexes/regexes.go
@@ -43,3 +43,45 @@ func Error() *regexp.Regexp {
 func Ignore() *regexp.Regexp {
 	return ignore
 }
+
+type normalization struct {
+	pattern     *regexp.Regexp
+	replacement string
+}
+
+// normalizations maps package set prefixes from packages.json to the canonical
+// names used by nixpkgs-update. These normalizations can be found in:
+// https://github.com/nix-community/infra/blob/1416f0bad404696b6cdeb7db2da6770abb3da2ac/hosts/build02/filter.sed
+// Note that the regexes that just drop packages entirely don't need to be
+// implemented, since those packages won't be in the `packages` table anyway.
+var normalizations = []normalization{
+	// beam: replace versioned with most-compatible (26)
+	{regexp.MustCompile(`^beam\w*2[0-9]*Packages`), "beam26Packages"},
+	// linux kernel: replace versioned generic kernels with unversioned
+	{regexp.MustCompile(`^linuxKernel\.packages\.linux_[0-9_]+\.`), "linuxPackages."},
+	// lua: replace versioned/jit variants with the version used by neovim
+	{regexp.MustCompile(`^lua\w*Packages`), "lua51Packages"},
+	// llvm: replace versioned with unversioned
+	{regexp.MustCompile(`^llvmPackages_\w*`), "llvmPackages"},
+	// ocaml: replace _latest with unversioned
+	{regexp.MustCompile(`^ocamlPackages_latest`), "ocamlPackages"},
+	// php extensions: replace versioned with unversioned
+	{regexp.MustCompile(`^php\w*Extensions`), "phpExtensions"},
+	// php packages: replace versioned with unversioned
+	{regexp.MustCompile(`^php\w*Packages`), "phpPackages"},
+	// postgresql: replace versioned/jit with unversioned
+	{regexp.MustCompile(`^postgresql\w*Packages`), "postgresqlPackages"},
+	// python3: replace versioned with unversioned
+	{regexp.MustCompile(`^python3\w*Packages`), "python3Packages"},
+}
+
+func NormalizeAttrPath(ap string) string {
+	for _, n := range normalizations {
+		replaced := n.pattern.ReplaceAllLiteralString(ap, n.replacement)
+
+		if replaced != ap {
+			return replaced
+		}
+	}
+	return ap
+}

--- a/regexes/regexes_test.go
+++ b/regexes/regexes_test.go
@@ -146,3 +146,50 @@ func TestFollowRegexp(t *testing.T) {
 		}
 	})
 }
+
+func TestNormalizeAttrPath(t *testing.T) {
+	tt := []struct {
+		input string
+		want  string
+	}{
+		// beam: versioned -> beam26Packages
+		{"beam27Packages.erlang", "beam26Packages.erlang"},
+		{"beam28Packages.elixir", "beam26Packages.elixir"},
+		// linux kernel: versioned generic -> linuxPackages
+		{"linuxKernel.packages.linux_6_6.foo", "linuxPackages.foo"},
+		{"linuxKernel.packages.linux_6_12.bar", "linuxPackages.bar"},
+		// lua: versioned -> lua51Packages
+		{"lua52Packages.foo", "lua51Packages.foo"},
+		{"lua53Packages.foo", "lua51Packages.foo"},
+		{"luajitPackages.foo", "lua51Packages.foo"},
+		// llvm: versioned -> unversioned
+		{"llvmPackages_17.clang", "llvmPackages.clang"},
+		{"llvmPackages_18.lld", "llvmPackages.lld"},
+		// ocaml: _latest -> unversioned
+		{"ocamlPackages_latest.foo", "ocamlPackages.foo"},
+		// php extensions: versioned -> unversioned
+		{"php82Extensions.foo", "phpExtensions.foo"},
+		{"php83Extensions.bar", "phpExtensions.bar"},
+		// php packages: versioned -> unversioned
+		{"php82Packages.foo", "phpPackages.foo"},
+		{"php83Packages.bar", "phpPackages.bar"},
+		// postgresql: versioned -> unversioned
+		{"postgresql15Packages.foo", "postgresqlPackages.foo"},
+		// python3: versioned -> unversioned
+		{"python312Packages.foo", "python3Packages.foo"},
+		{"python313Packages.bar", "python3Packages.bar"},
+		// no match: unchanged
+		{"haskellPackages.foo", "haskellPackages.foo"},
+		{"python2Packages.foo", "python2Packages.foo"},
+		{"btrbk", "btrbk"},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.input, func(t *testing.T) {
+			got := NormalizeAttrPath(tc.input)
+			if got != tc.want {
+				t.Errorf("NormalizeAttrPath(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The deployed version of the `nixpkgs-update` bot normalizes some attr paths that are published on the update log web page. See https://github.com/nix-community/infra/blob/master/hosts/build02/filter.sed for the current set of transformations.

This PR implements the same transformations, so that attr paths from `packages.json` can be matched to the nixpkgs-update logs.